### PR TITLE
changed rollImage to existng numpy functions

### DIFF
--- a/offaxisholo/reconstruct.py
+++ b/offaxisholo/reconstruct.py
@@ -151,19 +151,7 @@ def rollImage(img, x, y):
     x = w//2 and y = h//2, the function is equivalent to np.fft.fftshift(img).
     """
 
-    # Pick content of new quadrants
-    q1 = img[:y,:x]
-    q2 = img[:y,x:]
-    q3 = img[y:,x:]
-    q4 = img[y:,:x]
-
-    # Concatenate new quadrants
-    q21 = np.concatenate((q2, q1), axis=1)
-    q34 = np.concatenate((q3, q4), axis=1)
-    img = np.concatenate((q34, q21), axis=0)
-
-    # Done.
-    return img
+    return np.roll(img, (-y, -x), axis=(0,1))
 
 
 # =============================================================================


### PR DESCRIPTION
- the function is already covered by existing numpy functions
- verified similar functionality on following example:
`np.stack(np.meshgrid(range(11),range(13), indexing='ij'), axis=-1)`